### PR TITLE
pause menu bug fixed

### DIFF
--- a/Assets/Scenes/Player HUD/Player HUD.unity
+++ b/Assets/Scenes/Player HUD/Player HUD.unity
@@ -399,7 +399,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 50301457}
         m_TargetAssemblyTypeName: PauseMenu, Assembly-CSharp
-        m_MethodName: Pause
+        m_MethodName: PauseOrResume
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scripts/HUD/PauseMenu.cs
+++ b/Assets/Scripts/HUD/PauseMenu.cs
@@ -15,22 +15,25 @@ public class PauseMenu : MonoBehaviour
         //esc handling
         if (Input.GetKeyDown(KeyCode.Escape))
         {
-            //open menu when its not opened
-            if (!menuOpen && !subMenuOpen)
-            {
-                Pause();
-            }
-            //close menu when its opened
-            else if (menuOpen  && !subMenuOpen)
-            {
-                Resume();
-            }
-            //add option to go back out of a submenu into the normal pause menu again (instead of clicking the back button)
-            else
-            {
-                CloseSubMenu();
-            }
-            
+            PauseOrResume();
+        }
+    }
+    public void PauseOrResume()
+    {
+        //open menu when its not opened
+        if (!menuOpen && !subMenuOpen)
+        {
+            Pause();
+        }
+        //close menu when its opened
+        else if (menuOpen && !subMenuOpen)
+        {
+            Resume();
+        }
+        //add option to go back out of a submenu into the normal pause menu again (instead of clicking the back button)
+        else
+        {
+            CloseSubMenu();
         }
     }
     //handles everyting when pause menu is closed


### PR DESCRIPTION
the user could press on zoom out button, and due to the possibility (of unity i guess) he could choose with wasd other buttons to highlight. when now pressing space or enter to "press" the button, it was possible to oben many pause menu overlays over eachother.
This fixes this bug since the detection of the Game State (Paused/unpaused) is now in a function which is called by the esc button.

Fixes Gamify-IT/issues#160. 