### PR TITLE
Fix raccoon den colliders

### DIFF
--- a/Assets/Tiles/Overworld/Overworld.png.meta
+++ b/Assets/Tiles/Overworld/Overworld.png.meta
@@ -1651,7 +1651,15 @@ TextureImporter:
       pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
-      physicsShape: []
+      physicsShape:
+      - - {x: 2, y: -6}
+        - {x: -4, y: -7}
+        - {x: -7, y: -6}
+        - {x: -8, y: 1}
+        - {x: -6, y: 2}
+        - {x: 0, y: 4}
+        - {x: 7, y: 3}
+        - {x: 7, y: -3}
       tessellationDetail: 0
       bones: []
       spriteID: e836d4809670941d2af900ee6693fe1a
@@ -24725,19 +24733,19 @@ TextureImporter:
       Overworld_1049: -1251328357
       Overworld_896: 344632893
       Overworld_506: 52380106
-      Overworld_900: -580554469
       Overworld_51: 1063523783
       Overworld_653: 104214985
+      Overworld_939: -1312055616
       Overworld_473: -2060765553
-      Overworld_779: -788202271
+      Overworld_767: 1953966478
       Overworld_375: 288217588
       Overworld_688: -568623336
-      Overworld_767: 1953966478
+      Overworld_779: -788202271
       Overworld_858: -2135210929
       Overworld_79: 1466026303
       Overworld_1034: 117843936
       Overworld_359: -992884783
-      Overworld_939: -1312055616
+      Overworld_900: -580554469
       Overworld_142: -197147707
       Overworld_657: 1628432211
       Overworld_852: -20130233
@@ -24932,14 +24940,14 @@ TextureImporter:
       Overworld_94: 919427561
       Overworld_285: 1903084235
       Overworld_1008: 422195512
-      Overworld_873: -1893138960
       Overworld_160: -821045090
       Overworld_424: -975312629
+      Overworld_472: 1384830775
       Overworld_57: -1833946550
       Overworld_787: 266901770
+      Overworld_873: -1893138960
       Overworld_47: 1490266994
       Overworld_185: -1703106008
-      Overworld_472: 1384830775
       Overworld_410: 814520240
       Overworld_233: -1360227457
       Overworld_260: -1010785296
@@ -25210,13 +25218,13 @@ TextureImporter:
       Overworld_817: -111887290
       Overworld_1036: 1048557653
       Overworld_502: -1455429
+      Overworld_866: 1643336490
       Overworld_303: -561122651
-      Overworld_446: -1370269576
-      Overworld_1052: 245339362
       Overworld_452: -755437404
+      Overworld_446: -1370269576
       Overworld_317: 336629648
       Overworld_396: 1150126874
-      Overworld_866: 1643336490
+      Overworld_1052: 245339362
       Overworld_569: 1714161302
       Overworld_647: -1586757469
       Overworld_421: 537676764

--- a/Assets/Tiles/Special Tiles/raccoon-32-32.png.meta
+++ b/Assets/Tiles/Special Tiles/raccoon-32-32.png.meta
@@ -124,10 +124,14 @@ TextureImporter:
         width: 32
         height: 32
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
-      physicsShape: []
+      physicsShape:
+      - - {x: -4, y: -12}
+        - {x: -4, y: -9}
+        - {x: 7, y: -9}
+        - {x: 7, y: -12}
       tessellationDetail: 0
       bones: []
       spriteID: 4dc03370daafaef48bdbe4085eb19cfe


### PR DESCRIPTION
Closes Gamify-IT/issues#249

this fixes raccoon den colliders, and moves some npc raccons to the correct layer

to test this walk around in the raccoon den (raccoon den scene or walk to the spot of it) and see if colliders work as intended