### PR TITLE
Fix Minigame start overlay

### DIFF
--- a/.github/workflows/deploy-docker-image-on-release.yml
+++ b/.github/workflows/deploy-docker-image-on-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "bugfix/fix-ui-resizing"
     tags:
       - "v*"
   pull_request:

--- a/.github/workflows/deploy-docker-image-on-release.yml
+++ b/.github/workflows/deploy-docker-image-on-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "main"
-      - "fix/url-opener"
+      - "bugfix/fix-ui-resizing"
     tags:
       - "v*"
   pull_request:

--- a/Assets/Scenes/GameManager/MinigameStarting Overlay.unity
+++ b/Assets/Scenes/GameManager/MinigameStarting Overlay.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311915, g: 0.3807396, b: 0.35872662, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -156,10 +156,10 @@ RectTransform:
   m_Father: {fileID: 274941380}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -555, y: 89}
-  m_SizeDelta: {x: 200, y: 36.978}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 185, y: -65}
+  m_SizeDelta: {x: 200, y: 36.977997}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &47818328
 CanvasRenderer:
@@ -298,10 +298,10 @@ RectTransform:
   m_Father: {fileID: 1323897708}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.00012207031, y: -345.10934}
-  m_SizeDelta: {x: -390.4163, y: -728.3291}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 192}
+  m_SizeDelta: {x: 1051.797, y: 305.626}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &274941381
 MonoBehaviour:
@@ -390,9 +390,9 @@ RectTransform:
   m_Father: {fileID: 274941380}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 600, y: -100}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -140, y: 42}
   m_SizeDelta: {x: 220, y: 70}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &638502104
@@ -657,9 +657,9 @@ RectTransform:
   m_Father: {fileID: 274941380}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 61, y: -2}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 781.93, y: 0}
   m_SizeDelta: {x: 500, y: 36.978}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &794755277
@@ -792,9 +792,9 @@ RectTransform:
   m_Father: {fileID: 274941380}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -555, y: 2}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 185, y: 0}
   m_SizeDelta: {x: 200, y: 36.978}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1029626785
@@ -1030,9 +1030,9 @@ RectTransform:
   m_Father: {fileID: 274941380}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -618, y: -100}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 140, y: 42}
   m_SizeDelta: {x: 220, y: 70}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1417203044
@@ -1162,10 +1162,10 @@ RectTransform:
   m_Father: {fileID: 274941380}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 61, y: 89}
-  m_SizeDelta: {x: 500, y: 36.978}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 78.8, y: -65}
+  m_SizeDelta: {x: 500, y: 36.977997}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1491581448
 MonoBehaviour:


### PR DESCRIPTION
Closes Gamify-IT/issues#280

To test:
go to a minigame spot, resize the screen, see if it looks good all the time

I also resized the Minigame start HUD thing to be a bit smaller because it looked to wide for me, feel free to comment your opinion
![image](https://user-images.githubusercontent.com/101562444/188113567-d340ec23-c307-475a-a6d7-ae84aa560a93.png)
