### PR TITLE
add scripts for books with knowledge

### DIFF
--- a/Assets/Prefabs/Interactable/Book.prefab
+++ b/Assets/Prefabs/Interactable/Book.prefab
@@ -127,5 +127,5 @@ MonoBehaviour:
   world: 1
   dungeon: 0
   number: 1
-  nameOfBook: Empty Book
-  bookContent: []
+  nameOfBook: Mysterious Book
+  bookContent: 

--- a/Assets/Prefabs/Interactable/Book.prefab
+++ b/Assets/Prefabs/Interactable/Book.prefab
@@ -1,0 +1,113 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1556537105403999553
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1556537105403999558}
+  - component: {fileID: 1556537105403999559}
+  - component: {fileID: 1556537105403999552}
+  m_Layer: 8
+  m_Name: Book
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1556537105403999558
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1556537105403999553}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1556537105403999559
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1556537105403999553}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 458239855
+  m_SortingLayer: 1
+  m_SortingOrder: 4
+  m_Sprite: {fileID: -2024854000, guid: eb4b4d6c620c946c2aec968f281e9ec1, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!61 &1556537105403999552
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1556537105403999553}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.1781336, y: -0.06432605}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.52497697, y: 0.65362906}
+  m_EdgeRadius: 0

--- a/Assets/Prefabs/Interactable/Book.prefab
+++ b/Assets/Prefabs/Interactable/Book.prefab
@@ -12,7 +12,8 @@ GameObject:
   - component: {fileID: 1556537105403999559}
   - component: {fileID: 1556537105403999552}
   - component: {fileID: -8542897253286645159}
-  m_Layer: 8
+  - component: {fileID: 2921638665662489538}
+  m_Layer: 0
   m_Name: Book
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -96,7 +97,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0.1781336, y: -0.06432605}
@@ -129,3 +130,19 @@ MonoBehaviour:
   number: 1
   nameOfBook: Mysterious Book
   bookContent: 
+--- !u!70 &2921638665662489538
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1556537105403999553}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.15, y: -0.05}
+  m_Size: {x: 0.87, y: 1.92}
+  m_Direction: 1

--- a/Assets/Prefabs/Interactable/Book.prefab
+++ b/Assets/Prefabs/Interactable/Book.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 1556537105403999558}
   - component: {fileID: 1556537105403999559}
   - component: {fileID: 1556537105403999552}
+  - component: {fileID: -8542897253286645159}
   m_Layer: 8
   m_Name: Book
   m_TagString: Untagged
@@ -111,3 +112,20 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.52497697, y: 0.65362906}
   m_EdgeRadius: 0
+--- !u!114 &-8542897253286645159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1556537105403999553}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2fffd770988817042bc0805ef17de154, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  world: 1
+  dungeon: 0
+  number: 1
+  nameOfBook: Empty Book
+  bookContent: []

--- a/Assets/Prefabs/Interactable/Book.prefab.meta
+++ b/Assets/Prefabs/Interactable/Book.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: daddc452f34aba6418c7652a0535fa2b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Player HUD/Book.unity
+++ b/Assets/Scenes/Player HUD/Book.unity
@@ -1,0 +1,579 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &47818325
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 47818326}
+  - component: {fileID: 47818328}
+  - component: {fileID: 47818329}
+  m_Layer: 5
+  m_Name: Book_Name
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &47818326
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47818325}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.65, y: 1.65, z: 1.65}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 274941380}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 146, y: -32}
+  m_SizeDelta: {x: 169.69128, y: 36.978027}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &47818328
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47818325}
+  m_CullTransparentMesh: 1
+--- !u!114 &47818329
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 47818325}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Book Name
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 0ad93bae8466be34a9bdef4732fe6a58, type: 2}
+  m_sharedMaterial: {fileID: -8391701417571377768, guid: 0ad93bae8466be34a9bdef4732fe6a58, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 42.25
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &274941379
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 274941380}
+  - component: {fileID: 274941382}
+  - component: {fileID: 274941381}
+  m_Layer: 5
+  m_Name: BookPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &274941380
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 274941379}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 47818326}
+  - {fileID: 1465841980}
+  m_Father: {fileID: 1323897708}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1589.584, y: 961.93994}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &274941381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 274941379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.21960786, g: 0.21960786, b: 0.21960786, a: 0.8509804}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &274941382
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 274941379}
+  m_CullTransparentMesh: 1
+--- !u!1 &1323897704
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1323897708}
+  - component: {fileID: 1323897707}
+  - component: {fileID: 1323897706}
+  - component: {fileID: 1323897705}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1323897705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323897704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1323897706
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323897704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: -0.3
+  m_ScaleFactor: 0.5
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0.5
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1323897707
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323897704}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1323897708
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323897704}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 274941380}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &1465841979
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1465841980}
+  - component: {fileID: 1465841982}
+  - component: {fileID: 1465841983}
+  m_Layer: 5
+  m_Name: Book_Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1465841980
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465841979}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 274941380}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 5, y: -51.099}
+  m_SizeDelta: {x: 1553, y: 859.74}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1465841982
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465841979}
+  m_CullTransparentMesh: 1
+--- !u!114 &1465841983
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465841979}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+    eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
+    in culpa qui officia deserunt mollit anim id est laborum.
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 0ad93bae8466be34a9bdef4732fe6a58, type: 2}
+  m_sharedMaterial: {fileID: -8391701417571377768, guid: 0ad93bae8466be34a9bdef4732fe6a58, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 72
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/Scenes/Player HUD/Book.unity
+++ b/Assets/Scenes/Player HUD/Book.unity
@@ -388,7 +388,7 @@ MonoBehaviour:
   m_ReferencePixelsPerUnit: -0.3
   m_ScaleFactor: 0.5
   m_ReferenceResolution: {x: 1920, y: 1080}
-  m_ScreenMatchMode: 0
+  m_ScreenMatchMode: 1
   m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96

--- a/Assets/Scenes/Player HUD/Book.unity.meta
+++ b/Assets/Scenes/Player HUD/Book.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3fe4170a8634f99448d06508f3ad9937
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameManager/DTOs/BookDTO.cs
+++ b/Assets/Scripts/GameManager/DTOs/BookDTO.cs
@@ -23,13 +23,13 @@ public class BookDTO
     public string id;
     public AreaLocationDTO area;
     public int index;
-    public List<string> text;
+    public string text;
 
     #endregion
 
     #region Constructors
 
-    public BookDTO(string id, AreaLocationDTO area, int index, List<string> text)
+    public BookDTO(string id, AreaLocationDTO area, int index, string text)
     {
         this.id = id;
         this.area = area;

--- a/Assets/Scripts/GameManager/DTOs/BookDTO.cs
+++ b/Assets/Scripts/GameManager/DTOs/BookDTO.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+///     This class is used to retrieve data from Get Requests.
+/// </summary>
+[Serializable]
+public class BookDTO
+{
+    /// <summary>
+    ///     This function converts a json string to a <c>BookDTO</c> object.
+    /// </summary>
+    /// <param name="jsonString">The json string to convert</param>
+    /// <returns>A <c>BookDTO</c> object containing the data</returns>
+    public static BookDTO CreateFromJSON(string jsonString)
+    {
+        return JsonUtility.FromJson<BookDTO>(jsonString);
+    }
+
+    #region Attributes
+
+    public string id;
+    public AreaLocationDTO area;
+    public int index;
+    public List<string> text;
+
+    #endregion
+
+    #region Constructors
+
+    public BookDTO(string id, AreaLocationDTO area, int index, List<string> text)
+    {
+        this.id = id;
+        this.area = area;
+        this.index = index;
+        this.text = text;
+    }
+
+    public BookDTO()
+    {
+    }
+
+    #endregion
+}

--- a/Assets/Scripts/GameManager/DTOs/BookDTO.cs.meta
+++ b/Assets/Scripts/GameManager/DTOs/BookDTO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4fe8f368628c69b45915f45229a734c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameManager/DTOs/DungeonDTO.cs
+++ b/Assets/Scripts/GameManager/DTOs/DungeonDTO.cs
@@ -27,6 +27,7 @@ public class DungeonDTO
     public bool active;
     public List<MinigameTaskDTO> minigameTasks;
     public List<NPCDTO> npcs;
+    public List<BookDTO> books;
 
     #endregion
 
@@ -42,6 +43,7 @@ public class DungeonDTO
         this.active = active;
         this.minigameTasks = minigameTasks;
         this.npcs = npcs;
+        this.books = books;
     }
 
     public DungeonDTO()

--- a/Assets/Scripts/GameManager/DTOs/DungeonDTO.cs
+++ b/Assets/Scripts/GameManager/DTOs/DungeonDTO.cs
@@ -34,7 +34,7 @@ public class DungeonDTO
     #region Constructors
 
     public DungeonDTO(string id, int index, string staticName, string topicName, bool active,
-        List<MinigameTaskDTO> minigameTasks, List<NPCDTO> npcs)
+        List<MinigameTaskDTO> minigameTasks, List<NPCDTO> npcs, List<BookDTO> books)
     {
         this.id = id;
         this.index = index;

--- a/Assets/Scripts/GameManager/DTOs/WorldDTO.cs
+++ b/Assets/Scripts/GameManager/DTOs/WorldDTO.cs
@@ -27,6 +27,7 @@ public class WorldDTO
     public bool active;
     public List<MinigameTaskDTO> minigameTasks;
     public List<NPCDTO> npcs;
+    public List<BookDTO> books;
     public List<DungeonDTO> dungeons;
 
     #endregion
@@ -34,7 +35,7 @@ public class WorldDTO
     #region Constructors
 
     public WorldDTO(string id, int index, string staticName, string topicName, bool active,
-        List<MinigameTaskDTO> minigameTasks, List<NPCDTO> npcs, List<DungeonDTO> dungeons)
+        List<MinigameTaskDTO> minigameTasks, List<NPCDTO> npcs, List<DungeonDTO> dungeons, List<BookDTO> books)
     {
         this.id = id;
         this.index = index;
@@ -44,6 +45,7 @@ public class WorldDTO
         this.minigameTasks = minigameTasks;
         this.npcs = npcs;
         this.dungeons = dungeons;
+        this.books = books;
     }
 
     public WorldDTO()

--- a/Assets/Scripts/GameManager/Data Classes/DungeonData.cs
+++ b/Assets/Scripts/GameManager/Data Classes/DungeonData.cs
@@ -12,13 +12,14 @@ public class DungeonData
     private readonly bool active;
     private readonly MinigameData[] minigames;
     private readonly NPCData[] npcs;
+    private readonly BookData[] books;
 
     #endregion
 
     #region Constructors
 
     public DungeonData(string id, int index, string staticName, string topicName, bool active, MinigameData[] minigames,
-        NPCData[] npcs)
+        NPCData[] npcs, BookData[] books)
     {
         this.id = id;
         this.index = index;
@@ -27,6 +28,7 @@ public class DungeonData
         this.active = active;
         this.minigames = minigames;
         this.npcs = npcs;
+        this.books = books;
     }
 
     public DungeonData()
@@ -46,6 +48,12 @@ public class DungeonData
         for (int npcIndex = 1; npcIndex < npcs.Length; npcIndex++)
         {
             npcs[npcIndex] = new NPCData();
+        }
+        
+        books = new BookData[GameSettings.GetMaxBooks() + 1];
+        for (int bookIndex = 1; bookIndex < books.Length; bookIndex++)
+        {
+            books[bookIndex] = new BookData();
         }
     }
 
@@ -137,6 +145,21 @@ public class DungeonData
         return null;
     }
 
+    /// <summary>
+    ///     This function returns the data of a Book in the world.
+    /// </summary>
+    /// <param name="index">This index of the Book</param>
+    /// <returns>The data of the Book, <c>null</c> if invalid index</returns>
+    public BookData GetBookData(int index)
+    {
+        if (index > 0 && index < books.Length)
+        {
+            return books[index];
+        }
+
+        return null;
+    }
+    
     /// <summary>
     ///     This function returns whether the dungeon is set as active or not.
     /// </summary>

--- a/Assets/Scripts/GameManager/Data Classes/WorldData.cs
+++ b/Assets/Scripts/GameManager/Data Classes/WorldData.cs
@@ -12,6 +12,7 @@ public class WorldData
     private readonly bool active;
     private readonly MinigameData[] minigames;
     private readonly NPCData[] npcs;
+    private readonly BookData[] books;
     private readonly DungeonData[] dungeons;
 
     #endregion
@@ -19,7 +20,7 @@ public class WorldData
     #region Constructors
 
     public WorldData(string id, int index, string staticName, string topicName, bool active, MinigameData[] minigames,
-        NPCData[] npcs, DungeonData[] dungeons)
+        NPCData[] npcs, DungeonData[] dungeons, BookData[] books)
     {
         this.id = id;
         this.index = index;
@@ -28,6 +29,7 @@ public class WorldData
         this.active = active;
         this.minigames = minigames;
         this.npcs = npcs;
+        this.books = books;
         this.dungeons = dungeons;
     }
 
@@ -48,6 +50,12 @@ public class WorldData
         for (int npcIndex = 1; npcIndex < npcs.Length; npcIndex++)
         {
             npcs[npcIndex] = new NPCData();
+        }
+        
+        books = new BookData[GameSettings.GetMaxBooks() + 1];
+        for (int bookIndex = 1; bookIndex < books.Length; bookIndex++)
+        {
+            books[bookIndex] = new BookData();
         }
 
         dungeons = new DungeonData[GameSettings.GetMaxDungeons() + 1];
@@ -180,6 +188,21 @@ public class WorldData
         if (index > 0 && index < npcs.Length)
         {
             return npcs[index];
+        }
+
+        return null;
+    }
+    
+    /// <summary>
+    ///     This function returns the data of a Book in the world.
+    /// </summary>
+    /// <param name="index">This index of the Book</param>
+    /// <returns>The data of the Book, <c>null</c> if invalid index</returns>
+    public BookData getBookData(int index)
+    {
+        if (index > 0 && index < books.Length)
+        {
+            return books[index];
         }
 
         return null;

--- a/Assets/Scripts/GameManager/Data Classes/WorldData.cs
+++ b/Assets/Scripts/GameManager/Data Classes/WorldData.cs
@@ -51,7 +51,7 @@ public class WorldData
         {
             npcs[npcIndex] = new NPCData();
         }
-        
+
         books = new BookData[GameSettings.GetMaxBooks() + 1];
         for (int bookIndex = 1; bookIndex < books.Length; bookIndex++)
         {
@@ -192,7 +192,7 @@ public class WorldData
 
         return null;
     }
-    
+
     /// <summary>
     ///     This function returns the data of a Book in the world.
     /// </summary>

--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -339,6 +339,7 @@ public class GameManager : MonoBehaviour
             string[] emptyArray = { "" };
         }
     }
+
     /// <summary>
     ///     This function registers a new book at the <c>GameManager</c>
     /// </summary>
@@ -380,6 +381,7 @@ public class GameManager : MonoBehaviour
             string[] emptyArray = { "" };
         }
     }
+
     #endregion
 
     #region Loading
@@ -551,9 +553,9 @@ public class GameManager : MonoBehaviour
 
                 Debug.Log("    NPC slot " + worldIndex + "-" + npcIndex + " contains NPC: " + status);
             }
-            
+
             Debug.Log("  Books:");
-            for (int bookIndex = 1; bookIndex <= maxNPCs; bookIndex++)
+            for (int bookIndex = 1; bookIndex <= maxBooks; bookIndex++)
             {
                 string status = "";
                 if (bookObjects[worldIndex, bookIndex] != null)
@@ -879,14 +881,15 @@ public class GameManager : MonoBehaviour
 
         List<NPCDTO> npcDTOs = worldDTO.npcs;
         NPCData[] npcs = GetNpcData(npcDTOs);
-        
+
         List<BookDTO> bookDTOs = worldDTO.books;
         BookData[] books = GetBookData(bookDTOs);
 
         List<DungeonDTO> dungeonDTOs = worldDTO.dungeons;
         DungeonData[] dungeons = GetDungeonData(dungeonDTOs);
 
-        worldData[worldIndex] = new WorldData(id, index, staticName, topicName, active, minigames, npcs, dungeons, books);
+        worldData[worldIndex] =
+            new WorldData(id, index, staticName, topicName, active, minigames, npcs, dungeons, books);
     }
 
     /// <summary>
@@ -961,13 +964,13 @@ public class GameManager : MonoBehaviour
         foreach (BookDTO bookDTO in bookDTOs)
         {
             string uuid;
-            string[] bookText;
+            string bookText;
 
             uuid = bookDTO.id;
-            bookText = bookDTO.text.ToArray();
+            bookText = bookDTO.text;
             if (bookText.Length == 0)
             {
-                string[] dummyText = { "This is just an empty Book. No one has written anything here." };
+                string dummyText = "This is just an empty Book. No one has written anything here.";
                 bookText = dummyText;
             }
 
@@ -977,6 +980,7 @@ public class GameManager : MonoBehaviour
 
         return bookData;
     }
+
     /// <summary>
     ///     This function converts and list of <c>DungeonDTO</c> into a array of <c>DungeonData</c>
     /// </summary>
@@ -999,7 +1003,7 @@ public class GameManager : MonoBehaviour
 
             List<NPCDTO> npcDTOs = dungeonDTO.npcs;
             NPCData[] npcs = GetNpcData(npcDTOs);
-            
+
             List<BookDTO> bookDTOs = dungeonDTO.books;
             BookData[] books = GetBookData(bookDTOs);
 
@@ -1182,8 +1186,8 @@ public class GameManager : MonoBehaviour
 
             npc.Setup(npcData);
         }
-        
-        for (int bookIndex = 1; bookIndex <= maxNPCs; bookIndex++)
+
+        for (int bookIndex = 1; bookIndex <= maxBooks; bookIndex++)
         {
             BookData bookData = data.getBookData(bookIndex);
             if (bookData == null)
@@ -1351,7 +1355,7 @@ public class GameManager : MonoBehaviour
 
             npc.Setup(npcData);
         }
-        
+
         for (int bookIndex = 1; bookIndex <= maxBooks; bookIndex++)
         {
             BookData bookData = data.GetBookData(bookIndex);

--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -43,6 +43,7 @@ public class GameManager : MonoBehaviour
     private int maxWorld;
     private int maxMinigames;
     private int maxNPCs;
+    private int maxBooks;
     private int maxDungeons;
     private string courseId;
     private string userId;
@@ -53,6 +54,7 @@ public class GameManager : MonoBehaviour
     private GameObject[,] worldBarrierObjects;
     private GameObject[,] dungeonBarrierObjects;
     private GameObject[,] npcObjects;
+    private GameObject[,] bookObjects;
 
     //Data
     private WorldData[] worldData;
@@ -88,12 +90,14 @@ public class GameManager : MonoBehaviour
         maxWorld = GameSettings.GetMaxWorlds();
         maxMinigames = GameSettings.GetMaxMinigames();
         maxNPCs = GameSettings.GetMaxNpCs();
+        maxBooks = GameSettings.GetMaxBooks();
         maxDungeons = GameSettings.GetMaxDungeons();
 
         minigameObjects = new GameObject[maxWorld + 1, maxMinigames + 1];
         worldBarrierObjects = new GameObject[maxWorld + 1, maxWorld + 1];
         dungeonBarrierObjects = new GameObject[maxWorld + 1, maxDungeons + 1];
         npcObjects = new GameObject[maxWorld + 1, maxNPCs + 1];
+        bookObjects = new GameObject[maxWorld + 1, maxBooks + 1];
 
         worldData = new WorldData[maxWorld + 1];
         playerData = new PlayerstatisticDTO();
@@ -335,7 +339,47 @@ public class GameManager : MonoBehaviour
             string[] emptyArray = { "" };
         }
     }
+    /// <summary>
+    ///     This function registers a new book at the <c>GameManager</c>
+    /// </summary>
+    /// <param name="book">The npc gameObject</param>
+    /// <param name="world">The index of the world the book is in</param>
+    /// <param name="dungeon">The index of the dungeon the book is in (0 if in no dungeon)</param>
+    /// <param name="number">The index of the book in its area</param>
+    public void AddBook(GameObject book, int world, int dungeon, int number)
+    {
+        if (book != null)
+        {
+            if (dungeon == 0)
+            {
+                bookObjects[world, number] = book;
+            }
+            else
+            {
+                bookObjects[0, number] = book;
+            }
+        }
+    }
 
+    /// <summary>
+    ///     This function removes a book from the <c>GameManager</c>
+    /// </summary>
+    /// <param name="world">The index of the world the book is in</param>
+    /// <param name="dungeon">The index of the dungeon the book is in (0 if in no dungeon)</param>
+    /// <param name="number">The index of the book in its area</param>
+    public void RemoveBook(int world, int dungeon, int number)
+    {
+        if (dungeon == 0)
+        {
+            bookObjects[world, number] = null;
+            string[] emptyArray = { "" };
+        }
+        else
+        {
+            bookObjects[0, number] = null;
+            string[] emptyArray = { "" };
+        }
+    }
     #endregion
 
     #region Loading
@@ -507,6 +551,22 @@ public class GameManager : MonoBehaviour
 
                 Debug.Log("    NPC slot " + worldIndex + "-" + npcIndex + " contains NPC: " + status);
             }
+            
+            Debug.Log("  Books:");
+            for (int bookIndex = 1; bookIndex <= maxNPCs; bookIndex++)
+            {
+                string status = "";
+                if (bookObjects[worldIndex, bookIndex] != null)
+                {
+                    status = bookObjects[worldIndex, bookIndex].GetComponent<Book>().GetInfo();
+                }
+                else
+                {
+                    status = "none";
+                }
+
+                Debug.Log("    Book slot " + worldIndex + "-" + bookIndex + " contains book: " + status);
+            }
         }
     }
 
@@ -650,7 +710,7 @@ public class GameManager : MonoBehaviour
     }
 
     /// <summary>
-    ///     This function sends a GET request to the backend to get gerneral player data and logs the knowledge to the console
+    ///     This function sends a GET request to the backend to get general player data and logs the knowledge to the console
     /// </summary>
     /// <param name="uri">The path to send the GET request to</param>
     /// <returns></returns>
@@ -819,11 +879,14 @@ public class GameManager : MonoBehaviour
 
         List<NPCDTO> npcDTOs = worldDTO.npcs;
         NPCData[] npcs = GetNpcData(npcDTOs);
+        
+        List<BookDTO> bookDTOs = worldDTO.books;
+        BookData[] books = GetBookData(bookDTOs);
 
         List<DungeonDTO> dungeonDTOs = worldDTO.dungeons;
         DungeonData[] dungeons = GetDungeonData(dungeonDTOs);
 
-        worldData[worldIndex] = new WorldData(id, index, staticName, topicName, active, minigames, npcs, dungeons);
+        worldData[worldIndex] = new WorldData(id, index, staticName, topicName, active, minigames, npcs, dungeons, books);
     }
 
     /// <summary>
@@ -887,6 +950,34 @@ public class GameManager : MonoBehaviour
     }
 
     /// <summary>
+    ///     This function converts and list of <c>BookDTO</c> into a array of <c>BookData</c>
+    /// </summary>
+    /// <param name="bookDTOs">The list of <c>BookDTO</c> to convert</param>
+    /// <returns>The converted <c>BookData</c> array</returns>
+    private BookData[] GetBookData(List<BookDTO> bookDTOs)
+    {
+        BookData[] bookData = new BookData[maxBooks + 1];
+
+        foreach (BookDTO bookDTO in bookDTOs)
+        {
+            string uuid;
+            string[] bookText;
+
+            uuid = bookDTO.id;
+            bookText = bookDTO.text.ToArray();
+            if (bookText.Length == 0)
+            {
+                string[] dummyText = { "This is just an empty Book. No one has written anything here." };
+                bookText = dummyText;
+            }
+
+            BookData book = new BookData(uuid, bookText);
+            bookData[bookDTO.index] = book;
+        }
+
+        return bookData;
+    }
+    /// <summary>
     ///     This function converts and list of <c>DungeonDTO</c> into a array of <c>DungeonData</c>
     /// </summary>
     /// <param name="dungeonDTOs">The list of <c>DungeonDTO</c> to convert</param>
@@ -908,8 +999,11 @@ public class GameManager : MonoBehaviour
 
             List<NPCDTO> npcDTOs = dungeonDTO.npcs;
             NPCData[] npcs = GetNpcData(npcDTOs);
+            
+            List<BookDTO> bookDTOs = dungeonDTO.books;
+            BookData[] books = GetBookData(bookDTOs);
 
-            DungeonData dungeon = new DungeonData(id, index, staticName, topicName, active, minigames, npcs);
+            DungeonData dungeon = new DungeonData(id, index, staticName, topicName, active, minigames, npcs, books);
             dungeonData[index] = dungeon;
         }
 
@@ -1088,6 +1182,29 @@ public class GameManager : MonoBehaviour
 
             npc.Setup(npcData);
         }
+        
+        for (int bookIndex = 1; bookIndex <= maxNPCs; bookIndex++)
+        {
+            BookData bookData = data.getBookData(bookIndex);
+            if (bookData == null)
+            {
+                bookData = new BookData();
+            }
+
+            GameObject bookObject = bookObjects[worldIndex, bookIndex];
+            if (bookObject == null)
+            {
+                continue;
+            }
+
+            Book book = bookObject.GetComponent<Book>();
+            if (book == null)
+            {
+                continue;
+            }
+
+            book.Setup(bookData);
+        }
 
         for (int barrierDestinationIndex = 1; barrierDestinationIndex <= maxWorld; barrierDestinationIndex++)
         {
@@ -1233,6 +1350,29 @@ public class GameManager : MonoBehaviour
             }
 
             npc.Setup(npcData);
+        }
+        
+        for (int bookIndex = 1; bookIndex <= maxBooks; bookIndex++)
+        {
+            BookData bookData = data.GetBookData(bookIndex);
+            if (bookData == null)
+            {
+                bookData = new BookData();
+            }
+
+            GameObject bookObject = bookObjects[0, bookIndex];
+            if (bookObject == null)
+            {
+                continue;
+            }
+
+            Book book = bookObject.GetComponent<Book>();
+            if (book == null)
+            {
+                continue;
+            }
+
+            book.Setup(bookData);
         }
     }
 

--- a/Assets/Scripts/GameManager/GameSettings.cs
+++ b/Assets/Scripts/GameManager/GameSettings.cs
@@ -8,6 +8,7 @@ public static class GameSettings
     private static readonly int maxWorld = 4;
     private static readonly int maxMinigames = 12;
     private static readonly int maxNPCs = 10;
+    private static readonly int maxBooks = 1;
     private static readonly int maxDungeons = 4;
 
     #endregion
@@ -40,7 +41,14 @@ public static class GameSettings
     {
         return maxNPCs;
     }
-
+    /// <summary>
+    ///     This function returns the maximum amount of NPCs in an area.
+    /// </summary>
+    /// <returns>The maximum amount of NPCs in an area</returns>
+    public static int GetMaxBooks()
+    {
+        return maxBooks;
+    }
     /// <summary>
     ///     This function returns the maximum amount of dungeons in a world.
     /// </summary>

--- a/Assets/Scripts/Interactable/Book.cs
+++ b/Assets/Scripts/Interactable/Book.cs
@@ -1,0 +1,168 @@
+using System.Collections;
+using TMPro;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+/// <summary>
+///     This class is responsible for the Book logic.
+/// </summary>
+public class Book : MonoBehaviour
+{
+    [SerializeField] private int world;
+    [SerializeField] private int dungeon;
+    [SerializeField] private int number;
+    public string nameOfBook;
+    public string[] bookContent;
+    private TextMeshProUGUI bookText;
+    private int index;
+    private bool playerIsClose;
+    private string uuid;
+
+    /// <summary>
+    ///     This function is called when the object becomes enabled and active.
+    ///     It is used to initialize the Books.
+    /// </summary>
+    private void Awake()
+    {
+        RegisterToGameManager();
+    }
+
+    /// <summary>
+    ///     This method opens the Book text if the player is close to the Book and presses "E".
+    /// </summary>
+    private void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.E) && playerIsClose && !SceneManager.GetSceneByName("Book").isLoaded &&
+            !PauseMenu.menuOpen)
+        {
+            StartCoroutine(LoadBookScene());
+        }
+    }
+
+    /// <summary>
+    ///     This method removes the Book from the GameManager.
+    /// </summary>
+    private void OnDestroy()
+    {
+        Debug.Log("remove Book " + world + "-" + dungeon + "-" + number);
+        GameManager.Instance.RemoveNpc(world, dungeon, number); /////////////////////////////////////////
+    }
+
+    /// <summary>
+    ///     If the player is in range of the NPC the playerIsClose check will be set to true.
+    /// </summary>
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            playerIsClose = true;
+        }
+    }
+
+    /// <summary>
+    ///     If the player leaves the range of the Book while the Book window is open, the window will be closed, text will
+    ///     be reset and playerIsClose check will be set to false.
+    /// </summary>
+    private void OnTriggerExit2D(Collider2D other)
+    {
+        if (other.CompareTag("Player") && SceneManager.GetSceneByName("Book").isLoaded)
+        {
+            playerIsClose = false;
+        }
+    }
+
+
+    /// <summary>
+    ///     This function registers the NPC to the GameManager.
+    /// </summary>
+    private void RegisterToGameManager()
+    {
+        Debug.Log("register Book " + world + "-" + dungeon + "-" + number);
+        GameManager.Instance.AddNpc(gameObject, world, dungeon, number); //////////////////////////
+    }
+
+    /// <summary>
+    ///     setup called by game manager
+    /// </summary>
+    /// <param name="data"></param>
+    public void Setup(BookData data)
+    {
+        uuid = data.GetUuid();
+        bookContent = data.GetBookText();
+        string text = "";
+        for (int index = 0; index < bookContent.Length; index++)
+        {
+            text += bookContent[index];
+            text += " ; ";
+        }
+
+        Debug.Log("setup book " + world + "-" + number + " with new dialogue: " + text + ", new info: ");
+    }
+
+
+    /// <summary>
+    ///     This method loads the dialogue window and will change the text and name of the Book to the text and name set in the
+    ///     Book.
+    /// </summary>
+    private IEnumerator LoadBookScene()
+    {
+        var asyncLoadScene = SceneManager.LoadSceneAsync("Book", LoadSceneMode.Additive);
+        while (!asyncLoadScene.isDone)
+        {
+            yield return null;
+        }
+
+        GameObject.Find("Book_Name").GetComponent<TextMeshProUGUI>().text = nameOfBook;
+        bookText = GameObject.Find("Book_Text").GetComponent<TextMeshProUGUI>();
+    }
+
+    /// <summary>
+    ///     This function returns the Book object info
+    /// </summary>
+    /// <returns>NPC object info</returns>
+    public string GetInfo()
+    {
+        string info = "";
+        string text = "";
+        for (int index = 0; index < bookContent.Length; index++)
+        {
+            text += bookContent[index];
+            text += "; ";
+        }
+
+        info = world + "-" + dungeon + "-" + number + ": Text: " + text + ", completed: ";
+        return info;
+    }
+
+    #region Getter
+
+    /// <summary>
+    ///     This method returns the world index of the NPC.
+    /// </summary>
+    /// <returns>world</returns>
+    public int GetWorldIndex()
+    {
+        return world;
+    }
+
+    /// <summary>
+    ///     This method returns the dungeon index of the NPC.
+    /// </summary>
+    /// <returns>dungeon</returns>
+    public int GetDungeonIndex()
+    {
+        return dungeon;
+    }
+
+    /// <summary>
+    ///     This method returns the number of the NPC.
+    /// </summary>
+    /// <returns>number</returns>
+    public int getIndex()
+    {
+        return number;
+    }
+
+    #endregion
+}

--- a/Assets/Scripts/Interactable/Book.cs
+++ b/Assets/Scripts/Interactable/Book.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.UI;
 
 /// <summary>
 ///     This class is responsible for the Book logic.
@@ -13,7 +12,7 @@ public class Book : MonoBehaviour
     [SerializeField] private int dungeon;
     [SerializeField] private int number;
     public string nameOfBook;
-    public string[] bookContent;
+    public string bookContent;
     private TextMeshProUGUI bookText;
     private int index;
     private bool playerIsClose;
@@ -46,11 +45,11 @@ public class Book : MonoBehaviour
     private void OnDestroy()
     {
         Debug.Log("remove Book " + world + "-" + dungeon + "-" + number);
-        GameManager.Instance.RemoveNpc(world, dungeon, number); /////////////////////////////////////////
+        GameManager.Instance.RemoveBook(world, dungeon, number);
     }
 
     /// <summary>
-    ///     If the player is in range of the NPC the playerIsClose check will be set to true.
+    ///     If the player is in range of the Book the playerIsClose check will be set to true.
     /// </summary>
     private void OnTriggerEnter2D(Collider2D other)
     {
@@ -74,12 +73,12 @@ public class Book : MonoBehaviour
 
 
     /// <summary>
-    ///     This function registers the NPC to the GameManager.
+    ///     This function registers the Book to the GameManager.
     /// </summary>
     private void RegisterToGameManager()
     {
         Debug.Log("register Book " + world + "-" + dungeon + "-" + number);
-        GameManager.Instance.AddNpc(gameObject, world, dungeon, number); //////////////////////////
+        GameManager.Instance.AddBook(gameObject, world, dungeon, number);
     }
 
     /// <summary>
@@ -90,14 +89,8 @@ public class Book : MonoBehaviour
     {
         uuid = data.GetUuid();
         bookContent = data.GetBookText();
-        string text = "";
-        for (int index = 0; index < bookContent.Length; index++)
-        {
-            text += bookContent[index];
-            text += " ; ";
-        }
-
-        Debug.Log("setup book " + world + "-" + number + " with new dialogue: " + text + ", new info: ");
+        string text = bookContent;
+        Debug.Log("setup book " + world + "-" + number + " with Text: " + text);
     }
 
 
@@ -115,21 +108,17 @@ public class Book : MonoBehaviour
 
         GameObject.Find("Book_Name").GetComponent<TextMeshProUGUI>().text = nameOfBook;
         bookText = GameObject.Find("Book_Text").GetComponent<TextMeshProUGUI>();
+        bookText.text = bookContent;
     }
 
     /// <summary>
     ///     This function returns the Book object info
     /// </summary>
-    /// <returns>NPC object info</returns>
+    /// <returns>Book object info</returns>
     public string GetInfo()
     {
         string info = "";
-        string text = "";
-        for (int index = 0; index < bookContent.Length; index++)
-        {
-            text += bookContent[index];
-            text += "; ";
-        }
+        string text = bookContent;
 
         info = world + "-" + dungeon + "-" + number + ": Text: " + text + ", completed: ";
         return info;
@@ -138,7 +127,7 @@ public class Book : MonoBehaviour
     #region Getter
 
     /// <summary>
-    ///     This method returns the world index of the NPC.
+    ///     This method returns the world index of the Book.
     /// </summary>
     /// <returns>world</returns>
     public int GetWorldIndex()
@@ -147,7 +136,7 @@ public class Book : MonoBehaviour
     }
 
     /// <summary>
-    ///     This method returns the dungeon index of the NPC.
+    ///     This method returns the dungeon index of the Book.
     /// </summary>
     /// <returns>dungeon</returns>
     public int GetDungeonIndex()
@@ -156,7 +145,7 @@ public class Book : MonoBehaviour
     }
 
     /// <summary>
-    ///     This method returns the number of the NPC.
+    ///     This method returns the number of the Book.
     /// </summary>
     /// <returns>number</returns>
     public int getIndex()

--- a/Assets/Scripts/Interactable/Book.cs
+++ b/Assets/Scripts/Interactable/Book.cs
@@ -14,7 +14,6 @@ public class Book : MonoBehaviour
     public string nameOfBook;
     public string bookContent;
     private TextMeshProUGUI bookText;
-    private int index;
     private bool playerIsClose;
     private string uuid;
 
@@ -36,6 +35,11 @@ public class Book : MonoBehaviour
             !PauseMenu.menuOpen)
         {
             StartCoroutine(LoadBookScene());
+        }
+        else if (Input.GetKeyDown(KeyCode.E) && playerIsClose && SceneManager.GetSceneByName("Book").isLoaded &&
+                 !PauseMenu.menuOpen)
+        {
+            SceneManager.UnloadSceneAsync("Book");
         }
     }
 
@@ -66,6 +70,11 @@ public class Book : MonoBehaviour
     private void OnTriggerExit2D(Collider2D other)
     {
         if (other.CompareTag("Player") && SceneManager.GetSceneByName("Book").isLoaded)
+        {
+            playerIsClose = false;
+            SceneManager.UnloadSceneAsync("Book");
+        }
+        else if (other.CompareTag("Player") && !SceneManager.GetSceneByName("Book").isLoaded)
         {
             playerIsClose = false;
         }

--- a/Assets/Scripts/Interactable/Book.cs.meta
+++ b/Assets/Scripts/Interactable/Book.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fffd770988817042bc0805ef17de154
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactable/BookData.cs
+++ b/Assets/Scripts/Interactable/BookData.cs
@@ -3,7 +3,7 @@
 /// </summary>
 public class BookData
 {
-    public BookData(string uuid, string[] bookText)
+    public BookData(string uuid, string bookText)
     {
         this.uuid = uuid;
         this.bookText = bookText;
@@ -12,21 +12,21 @@ public class BookData
     public BookData()
     {
         uuid = "";
-        string[] text = { "This is just an empty Book. No one has written anything here." };
+        string text = "This is just an empty Book. No one has written anything here.";
         bookText = text;
     }
 
     #region Attributes
 
     private string uuid;
-    private string[] bookText;
+    private string bookText;
 
     #endregion
 
     #region GetterAndSetter
 
     /// <summary>
-    ///     This method returns the UUID of the NPC.
+    ///     This method returns the UUID of the Book.
     /// </summary>
     /// <returns>uuid</returns>
     public string GetUuid()
@@ -35,30 +35,30 @@ public class BookData
     }
 
     /// <summary>
-    ///     This method sets the UUID of the NPC.
+    ///     This method sets the UUID of the Book
     /// </summary>
-    /// <param name="uuid">uuid of the NPC</param>
+    /// <param name="uuid">uuid of the Book</param>
     public void SetUuid(string uuid)
     {
         this.uuid = uuid;
     }
 
     /// <summary>
-    ///     This method returns the dialogue of the NPC.
+    ///     This method returns the dialogue of the Book.
     /// </summary>
-    /// <returns>dialogue</returns>
-    public string[] GetBookText()
+    /// <returns>bookText</returns>
+    public string GetBookText()
     {
         return bookText;
     }
 
     /// <summary>
-    ///     This method is used to set the dialogue of the NPC.
+    ///     This method is used to set the dialogue of the Book.
     /// </summary>
-    /// <param name="dialogue">the dialogue of the NPC</param>
-    public void SetBookText(string[] dialogue)
+    /// <param name="bookText">the content of the Book</param>
+    public void SetBookText(string bookText)
     {
-        this.bookText = dialogue;
+        this.bookText = bookText;
     }
 
     #endregion

--- a/Assets/Scripts/Interactable/BookData.cs
+++ b/Assets/Scripts/Interactable/BookData.cs
@@ -3,23 +3,23 @@
 /// </summary>
 public class BookData
 {
-    public BookData(string uuid, string[] dialogue, bool hasBeenTalkedTo)
+    public BookData(string uuid, string[] bookText)
     {
         this.uuid = uuid;
-        this.dialogue = dialogue;
+        this.bookText = bookText;
     }
 
     public BookData()
     {
         uuid = "";
-        string[] text = { "Hi.", "I have nothing to say." };
-        dialogue = text;
+        string[] text = { "This is just an empty Book. No one has written anything here." };
+        bookText = text;
     }
 
     #region Attributes
 
     private string uuid;
-    private string[] dialogue;
+    private string[] bookText;
 
     #endregion
 
@@ -49,7 +49,7 @@ public class BookData
     /// <returns>dialogue</returns>
     public string[] GetBookText()
     {
-        return dialogue;
+        return bookText;
     }
 
     /// <summary>
@@ -58,7 +58,7 @@ public class BookData
     /// <param name="dialogue">the dialogue of the NPC</param>
     public void SetBookText(string[] dialogue)
     {
-        this.dialogue = dialogue;
+        this.bookText = dialogue;
     }
 
     #endregion

--- a/Assets/Scripts/Interactable/BookData.cs
+++ b/Assets/Scripts/Interactable/BookData.cs
@@ -1,0 +1,65 @@
+/// <summary>
+///     This class defines all needed data for a <c>Book</c>.
+/// </summary>
+public class BookData
+{
+    public BookData(string uuid, string[] dialogue, bool hasBeenTalkedTo)
+    {
+        this.uuid = uuid;
+        this.dialogue = dialogue;
+    }
+
+    public BookData()
+    {
+        uuid = "";
+        string[] text = { "Hi.", "I have nothing to say." };
+        dialogue = text;
+    }
+
+    #region Attributes
+
+    private string uuid;
+    private string[] dialogue;
+
+    #endregion
+
+    #region GetterAndSetter
+
+    /// <summary>
+    ///     This method returns the UUID of the NPC.
+    /// </summary>
+    /// <returns>uuid</returns>
+    public string GetUuid()
+    {
+        return uuid;
+    }
+
+    /// <summary>
+    ///     This method sets the UUID of the NPC.
+    /// </summary>
+    /// <param name="uuid">uuid of the NPC</param>
+    public void SetUuid(string uuid)
+    {
+        this.uuid = uuid;
+    }
+
+    /// <summary>
+    ///     This method returns the dialogue of the NPC.
+    /// </summary>
+    /// <returns>dialogue</returns>
+    public string[] GetBookText()
+    {
+        return dialogue;
+    }
+
+    /// <summary>
+    ///     This method is used to set the dialogue of the NPC.
+    /// </summary>
+    /// <param name="dialogue">the dialogue of the NPC</param>
+    public void SetBookText(string[] dialogue)
+    {
+        this.dialogue = dialogue;
+    }
+
+    #endregion
+}

--- a/Assets/Scripts/Interactable/BookData.cs.meta
+++ b/Assets/Scripts/Interactable/BookData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 343eb0ef1b5521045af24424b106c7a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.analytics": "3.6.12",
     "com.unity.collab-proxy": "1.15.16",
     "com.unity.feature.2d": "1.0.0",
-    "com.unity.ide.rider": "3.0.14",
+    "com.unity.ide.rider": "3.0.15",
     "com.unity.ide.visualstudio": "2.0.15",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.purchasing": "4.1.3",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -143,7 +143,7 @@
       }
     },
     "com.unity.ide.rider": {
-      "version": "3.0.14",
+      "version": "3.0.15",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -107,4 +107,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/GameManager/InfoScreen.unity
     guid: 432e5bce190e755438c1ac881de805cf
+  - enabled: 1
+    path: Assets/Scenes/Player HUD/Book.unity
+    guid: 3fe4170a8634f99448d06508f3ad9937
   m_configObjects: {}


### PR DESCRIPTION
Part of Gamify-IT/issues#120

This adds Gamemanager Scripts and logic for Books that could be configured.

There needs to be a backend implementation and lecturer interface implementation so they can actually be configured.

To Review this please go over the Code and see if all needed Functions and Scripts are there. I oriented my scripts on the NPC scripts, and adapted them since Books dont need as much info as a NPC

There is now a Book Prefab in Unity available which should work like the NPC prefab

the overlay currently looks simple like this
![image](https://user-images.githubusercontent.com/101562444/189622281-b030523c-5628-4106-b5b6-9327069cb93a.png)
