### PR TITLE
progress bar

### DIFF
--- a/.github/workflows/deploy-docker-image-on-release.yml
+++ b/.github/workflows/deploy-docker-image-on-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "feature/progress-bar"
     tags:
       - "v*"
   pull_request:

--- a/Assets/Scenes/Player HUD/Player HUD.unity
+++ b/Assets/Scenes/Player HUD/Player HUD.unity
@@ -788,82 +788,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 1
---- !u!1 &653241966
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 653241967}
-  - component: {fileID: 653241969}
-  - component: {fileID: 653241968}
-  m_Layer: 5
-  m_Name: Level Number
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &653241967
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 653241966}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 1652307031}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -32.88, y: 3.54}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &653241968
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 653241966}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 2075259625, guid: 926e9b44ee2d8b34dbe5d7557f66048b, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 1
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &653241969
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 653241966}
-  m_CullTransparentMesh: 1
 --- !u!1 &1011902166
 GameObject:
   m_ObjectHideFlags: 0
@@ -1307,7 +1231,7 @@ GameObject:
   - component: {fileID: 1319406728}
   - component: {fileID: 1319406727}
   m_Layer: 5
-  m_Name: Fill
+  m_Name: Progress
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1358,7 +1282,7 @@ MonoBehaviour:
   m_PreserveAspect: 1
   m_FillCenter: 1
   m_FillMethod: 0
-  m_FillAmount: 0.759
+  m_FillAmount: 1
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
@@ -1485,6 +1409,141 @@ RectTransform:
   m_AnchoredPosition: {x: -74.999985, y: -85.825}
   m_SizeDelta: {x: 150, y: 21.6507}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1648503683
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1648503684}
+  - component: {fileID: 1648503686}
+  - component: {fileID: 1648503685}
+  m_Layer: 5
+  m_Name: Unlocked Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1648503684
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1648503683}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1652307031}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -30, y: 3.5}
+  m_SizeDelta: {x: 20, y: 10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1648503685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1648503683}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 3-3
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 0ad93bae8466be34a9bdef4732fe6a58, type: 2}
+  m_sharedMaterial: {fileID: -8391701417571377768, guid: 0ad93bae8466be34a9bdef4732fe6a58, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278244351
+  m_fontColor: {r: 1, g: 0.82689786, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12
+  m_fontSizeBase: 12
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1648503686
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1648503683}
+  m_CullTransparentMesh: 1
 --- !u!1 &1652307030
 GameObject:
   m_ObjectHideFlags: 0
@@ -1496,6 +1555,7 @@ GameObject:
   - component: {fileID: 1652307031}
   - component: {fileID: 1652307033}
   - component: {fileID: 1652307032}
+  - component: {fileID: 1652307034}
   m_Layer: 5
   m_Name: Level
   m_TagString: Untagged
@@ -1516,7 +1576,7 @@ RectTransform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 1319406726}
-  - {fileID: 653241967}
+  - {fileID: 1648503684}
   m_Father: {fileID: 50301456}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1563,6 +1623,20 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1652307030}
   m_CullTransparentMesh: 1
+--- !u!114 &1652307034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1652307030}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6e6f70b05797d094aa478485506f7faa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  slider: {fileID: 1319406727}
+  unlockedAreaText: {fileID: 1648503685}
 --- !u!1 &2013672144
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameManager/DTOs/PlayerstatisticDTO.cs
+++ b/Assets/Scripts/GameManager/DTOs/PlayerstatisticDTO.cs
@@ -46,10 +46,16 @@ public class PlayerstatisticDTO
     public PlayerstatisticDTO()
     {
         id = "";
-        AreaLocationDTO unlockedArea = new AreaLocationDTO();
-        unlockedAreas = new AreaLocationDTO[1];
-        unlockedAreas[0] = unlockedArea;
-        currentArea = unlockedArea;
+        AreaLocationDTO unlockedWorld = new AreaLocationDTO();
+        unlockedWorld.worldIndex = 1;
+        unlockedWorld.dungeonIndex = 0;
+        AreaLocationDTO unlockedDungeon = new AreaLocationDTO();
+        unlockedDungeon.worldIndex = 1;
+        unlockedDungeon.dungeonIndex = 1;
+        unlockedAreas = new AreaLocationDTO[2];
+        unlockedAreas[0] = unlockedWorld;
+        unlockedAreas[1] = unlockedDungeon;
+        currentArea = unlockedWorld;
         unlockedDungeons = null;
         userId = "";
         username = "";

--- a/Assets/Scripts/GameManager/Data Classes/DungeonData.cs
+++ b/Assets/Scripts/GameManager/Data Classes/DungeonData.cs
@@ -181,5 +181,14 @@ public class DungeonData
         }
     }
 
+    /// <summary>
+    /// This function the data of all minigames in the world.
+    /// </summary>
+    /// <returns>The data of the minigames</returns>
+    public MinigameData[] GetMinigameData()
+    {
+        return minigames;
+    }
+
     #endregion
 }

--- a/Assets/Scripts/GameManager/Data Classes/WorldData.cs
+++ b/Assets/Scripts/GameManager/Data Classes/WorldData.cs
@@ -267,5 +267,14 @@ public class WorldData
         }
     }
 
+    /// <summary>
+    /// This function the data of all minigames in the world.
+    /// </summary>
+    /// <returns>The data of the minigames</returns>
+    public MinigameData[] GetMinigameData()
+    {
+        return minigames;
+    }
+
     #endregion
 }

--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -1474,6 +1474,11 @@ public class GameManager : MonoBehaviour
         return playerData.unlockedAreas;
     }
 
+    /// <summary>
+    /// This function returns the percentage of completed minigames in the given world
+    /// </summary>
+    /// <param name="worldIndex">The index of the world</param>
+    /// <returns>The percentage of completed minigames</returns>
     public float getMinigameProgress(int worldIndex)
     {
         MinigameData[] minigameData = worldData[worldIndex].GetMinigameData();
@@ -1492,6 +1497,12 @@ public class GameManager : MonoBehaviour
         return (completedMinigames * 1f) / (minigameData.Length * 1f);
     }
 
+    /// <summary>
+    /// This function returns the percentage of completed minigames in the given dungeon
+    /// </summary>
+    /// <param name="worldIndex">The index of the world the dungeon is in</param>
+    /// <param name="dungeonIndex">The index of the dungeon</param>
+    /// <returns>The percentage of completed minigames</returns>
     public float getMinigameProgress(int worldIndex, int dungeonIndex)
     {
         MinigameData[] minigameData = worldData[worldIndex].getDungeonData(dungeonIndex).GetMinigameData();

--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -1474,5 +1474,41 @@ public class GameManager : MonoBehaviour
         return playerData.unlockedAreas;
     }
 
+    public float getMinigameProgress(int worldIndex)
+    {
+        MinigameData[] minigameData = worldData[worldIndex].GetMinigameData();
+        if(minigameData.Length == 0)
+        {
+            return 0f;
+        }
+        int completedMinigames = 0; 
+        foreach(MinigameData data in minigameData)
+        {
+            if(data.GetStatus() == global::MinigameStatus.done)
+            {
+                completedMinigames++;
+            }
+        }
+        return (completedMinigames * 1f) / (minigameData.Length * 1f);
+    }
+
+    public float getMinigameProgress(int worldIndex, int dungeonIndex)
+    {
+        MinigameData[] minigameData = worldData[worldIndex].getDungeonData(dungeonIndex).GetMinigameData();
+        if (minigameData.Length == 0)
+        {
+            return 0f;
+        }
+        int completedMinigames = 0;
+        foreach (MinigameData data in minigameData)
+        {
+            if (data.GetStatus() == global::MinigameStatus.done)
+            {
+                completedMinigames++;
+            }
+        }
+        return (completedMinigames * 1f) / (minigameData.Length * 1f);
+    }
+
     #endregion
 }

--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -1481,20 +1481,28 @@ public class GameManager : MonoBehaviour
     /// <returns>The percentage of completed minigames</returns>
     public float getMinigameProgress(int worldIndex)
     {
-        MinigameData[] minigameData = worldData[worldIndex].GetMinigameData();
-        if(minigameData.Length == 0)
+        int completedMinigames = 0;
+        int minigames = 0;
+        for(int minigameIndex=1; minigameIndex <= GameSettings.GetMaxMinigames(); minigameIndex++)
+        {
+            if(worldData[worldIndex].getMinigameData(minigameIndex) != null)
+            {
+                minigames++;
+                if(worldData[worldIndex].getMinigameStatus(minigameIndex) == global::MinigameStatus.done)
+                {
+                    completedMinigames++;
+                }
+            }
+        }
+        Debug.Log(completedMinigames + "/" + minigames + " minigames completed");
+        if(minigames == 0)
         {
             return 0f;
         }
-        int completedMinigames = 0; 
-        foreach(MinigameData data in minigameData)
+        else
         {
-            if(data.GetStatus() == global::MinigameStatus.done)
-            {
-                completedMinigames++;
-            }
+            return (completedMinigames * 1f) / (minigames * 1f);
         }
-        return (completedMinigames * 1f) / (minigameData.Length * 1f);
     }
 
     /// <summary>
@@ -1505,20 +1513,33 @@ public class GameManager : MonoBehaviour
     /// <returns>The percentage of completed minigames</returns>
     public float getMinigameProgress(int worldIndex, int dungeonIndex)
     {
-        MinigameData[] minigameData = worldData[worldIndex].getDungeonData(dungeonIndex).GetMinigameData();
-        if (minigameData.Length == 0)
+        int completedMinigames = 0;
+        int minigames = 0;
+        DungeonData dungeonData = worldData[worldIndex].getDungeonData(dungeonIndex);
+        if(dungeonData == null)
         {
             return 0f;
         }
-        int completedMinigames = 0;
-        foreach (MinigameData data in minigameData)
+        for (int minigameIndex = 1; minigameIndex <= GameSettings.GetMaxMinigames(); minigameIndex++)
         {
-            if (data.GetStatus() == global::MinigameStatus.done)
+            if (dungeonData.GetMinigameData(minigameIndex) != null)
             {
-                completedMinigames++;
+                minigames++;
+                if (worldData[worldIndex].getMinigameStatus(minigameIndex, dungeonIndex) == global::MinigameStatus.done)
+                {
+                    completedMinigames++;
+                }
             }
         }
-        return (completedMinigames * 1f) / (minigameData.Length * 1f);
+        Debug.Log(completedMinigames + "/" + minigames + " minigames completed");
+        if (minigames == 0)
+        {
+            return 0f;
+        }
+        else
+        {
+            return (completedMinigames * 1f) / (minigames * 1f);
+        }
     }
 
     #endregion

--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -1487,9 +1487,13 @@ public class GameManager : MonoBehaviour
         {
             if(worldData[worldIndex].getMinigameData(minigameIndex) != null)
             {
-                minigames++;
-                if(worldData[worldIndex].getMinigameStatus(minigameIndex) == global::MinigameStatus.done)
+                if (worldData[worldIndex].getMinigameStatus(minigameIndex) == global::MinigameStatus.active)
                 {
+                    minigames++;
+                }   
+                else if(worldData[worldIndex].getMinigameStatus(minigameIndex) == global::MinigameStatus.done)
+                {
+                    minigames++;
                     completedMinigames++;
                 }
             }
@@ -1524,9 +1528,13 @@ public class GameManager : MonoBehaviour
         {
             if (dungeonData.GetMinigameData(minigameIndex) != null)
             {
-                minigames++;
-                if (worldData[worldIndex].getMinigameStatus(minigameIndex, dungeonIndex) == global::MinigameStatus.done)
+                if (worldData[worldIndex].getMinigameStatus(minigameIndex, dungeonIndex) == global::MinigameStatus.active)
                 {
+                    minigames++;
+                }  
+                else if (worldData[worldIndex].getMinigameStatus(minigameIndex, dungeonIndex) == global::MinigameStatus.done)
+                {
+                    minigames++;
                     completedMinigames++;
                 }
             }

--- a/Assets/Scripts/GameManager/GameSettings.cs
+++ b/Assets/Scripts/GameManager/GameSettings.cs
@@ -8,7 +8,7 @@ public static class GameSettings
     private static readonly int maxWorld = 4;
     private static readonly int maxMinigames = 12;
     private static readonly int maxNPCs = 10;
-    private static readonly int maxBooks = 1;
+    private static readonly int maxBooks = 5;
     private static readonly int maxDungeons = 4;
 
     #endregion

--- a/Assets/Scripts/HUD/ProgressBar.cs
+++ b/Assets/Scripts/HUD/ProgressBar.cs
@@ -1,0 +1,64 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class ProgressBar : MonoBehaviour
+{
+    #region Attributes
+    [SerializeField] private Image slider;
+    [SerializeField] private TextMeshProUGUI unlockedAreaText;
+    #endregion
+
+    #region Singleton
+
+    public static ProgressBar Instance { get; private set; }
+
+    /// <summary>
+    ///     This function manages the singleton instance, so it initializes the <c>Instance</c> variable, if not set, or
+    ///     deletes the object otherwise
+    /// </summary>
+    private void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    #endregion
+
+    /// <summary>
+    /// This function sets the progress bar at the given value.
+    /// </summary>
+    /// <param name="progress">The progress in percent (must be between 0 and 1)</param>
+    public void setProgress(float progress)
+    {
+        if(0f <= progress && progress <= 1f)
+        {
+            slider.fillAmount = progress;
+        }
+    }
+
+    /// <summary>
+    /// This function sets the unlocked area for a world
+    /// </summary>
+    /// <param name="worldIndex">The index of the unlocked world</param>
+    public void setUnlockedArea(int worldIndex)
+    {
+        unlockedAreaText.text = worldIndex.ToString();
+    }
+
+    /// <summary>
+    /// This function sets the unlocked area for a dungeon
+    /// </summary>
+    /// <param name="worldIndex">The index of the world the unlocked dungeon is in</param>
+    /// <param name="dungeonIndex">The index of the unlocked dungeon</param>
+    public void setUnlockedArea(int worldIndex, int dungeonIndex)
+    {
+        unlockedAreaText.text = worldIndex + "-" + dungeonIndex;
+    }
+}

--- a/Assets/Scripts/HUD/ProgressBar.cs.meta
+++ b/Assets/Scripts/HUD/ProgressBar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e6f70b05797d094aa478485506f7faa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Scene Loading/LoadingManager.cs
+++ b/Assets/Scripts/Scene Loading/LoadingManager.cs
@@ -237,7 +237,7 @@ public class LoadingManager : MonoBehaviour
     /// <param name="unlockedAreasOld">Set of unlocked areas before the reload</param>
     /// <param name="unlockedAreasNew">Set of unlocked areas after the reload</param>
     /// <returns>A info text to display, if a newly unlocked area was found, "" otherwise</returns>
-    public string CheckForNewUnlockedArea(AreaLocationDTO[] unlockedAreasOld, AreaLocationDTO[] unlockedAreasNew)
+    private string CheckForNewUnlockedArea(AreaLocationDTO[] unlockedAreasOld, AreaLocationDTO[] unlockedAreasNew)
     {
         string infoText = "";
         foreach (AreaLocationDTO newLocation in unlockedAreasNew)
@@ -272,6 +272,10 @@ public class LoadingManager : MonoBehaviour
         return infoText;
     }
 
+    /// <summary>
+    /// This function sets up the progress with the highest unlocked area and the minigame progress in that area
+    /// </summary>
+    /// <param name="unlockedAreas">All unlocked areas</param>
     private void SetupProgessBar(AreaLocationDTO[] unlockedAreas)
     {
         for(int worldIndex = GameSettings.GetMaxWorlds(); worldIndex > 0; worldIndex--)
@@ -287,11 +291,18 @@ public class LoadingManager : MonoBehaviour
                 {
                     ProgressBar.Instance.setUnlockedArea(worldIndex, dungeonIndex);
                 }
+                break;
             }
         }
         ProgressBar.Instance.setUnlockedArea(1);
     }
 
+    /// <summary>
+    /// This function checks whether the player has unlocked a world or not
+    /// </summary>
+    /// <param name="unlockedAreas">All unlocked areas</param>
+    /// <param name="worldIndex">The index of the world to be checked</param>
+    /// <returns>True, if the world is unlocked, false otherwise</returns>
     private bool isWorldUnlocked(AreaLocationDTO[] unlockedAreas, int worldIndex)
     {
         for (int index = 0; index < unlockedAreas.Length; index++)
@@ -304,6 +315,13 @@ public class LoadingManager : MonoBehaviour
         return false;
     }
 
+    /// <summary>
+    /// This function checks whether the player has unlocked a dungeon or not
+    /// </summary>
+    /// <param name="unlockedAreas">All unlocked areas</param>
+    /// <param name="worldIndex">The index of the world the dungeon to be checked is in</param>
+    /// <param name="dungeonIndex">The index of the dungeon to be checked</param>
+    /// <returns>True, if the dungeon is unlocked, false otherwise</returns>
     private bool isDungeonUnlocked(AreaLocationDTO[] unlockedAreas, int worldIndex, int dungeonIndex)
     {
         for (int index = 0; index < unlockedAreas.Length; index++)
@@ -316,6 +334,12 @@ public class LoadingManager : MonoBehaviour
         return false;
     }
 
+    /// <summary>
+    /// This function returns the highest unlocked dungeon of a given world
+    /// </summary>
+    /// <param name="unlockedAreas">All unlocked areas</param>
+    /// <param name="worldIndex">The index of the world</param>
+    /// <returns></returns>
     private int getHighestUnlockedDungeonIndex(AreaLocationDTO[] unlockedAreas, int worldIndex)
     {
         for(int dungeonIndex = GameSettings.GetMaxDungeons(); dungeonIndex > 0; dungeonIndex--)

--- a/Assets/Scripts/Scene Loading/LoadingManager.cs
+++ b/Assets/Scripts/Scene Loading/LoadingManager.cs
@@ -279,6 +279,7 @@ public class LoadingManager : MonoBehaviour
     private void SetupProgessBar(AreaLocationDTO[] unlockedAreas)
     {
         ProgressBar.Instance.setUnlockedArea(1);
+        ProgressBar.Instance.setProgress(0f);
         for (int worldIndex = GameSettings.GetMaxWorlds(); worldIndex > 0; worldIndex--)
         {
             if(isWorldUnlocked(unlockedAreas, worldIndex))
@@ -287,10 +288,14 @@ public class LoadingManager : MonoBehaviour
                 if(dungeonIndex == 0)
                 {
                     ProgressBar.Instance.setUnlockedArea(worldIndex);
+                    float progress = GameManager.Instance.getMinigameProgress(worldIndex);
+                    ProgressBar.Instance.setProgress(progress);
                 }
                 else
                 {
                     ProgressBar.Instance.setUnlockedArea(worldIndex, dungeonIndex);
+                    float progress = GameManager.Instance.getMinigameProgress(worldIndex, dungeonIndex);
+                    ProgressBar.Instance.setProgress(progress);
                 }
                 break;
             }

--- a/Assets/Scripts/Scene Loading/LoadingManager.cs
+++ b/Assets/Scripts/Scene Loading/LoadingManager.cs
@@ -278,7 +278,8 @@ public class LoadingManager : MonoBehaviour
     /// <param name="unlockedAreas">All unlocked areas</param>
     private void SetupProgessBar(AreaLocationDTO[] unlockedAreas)
     {
-        for(int worldIndex = GameSettings.GetMaxWorlds(); worldIndex > 0; worldIndex--)
+        ProgressBar.Instance.setUnlockedArea(1);
+        for (int worldIndex = GameSettings.GetMaxWorlds(); worldIndex > 0; worldIndex--)
         {
             if(isWorldUnlocked(unlockedAreas, worldIndex))
             {
@@ -294,7 +295,6 @@ public class LoadingManager : MonoBehaviour
                 break;
             }
         }
-        ProgressBar.Instance.setUnlockedArea(1);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes Gamify-IT/issues#233

To test you need to play minigames and see if the bar fills up more after every succesful finished minigame.
when completing all minigames a new area unlocks and it should be displayed in the HUD (for this you need to have a configured dungeon that is activated)