### PR TITLE
fix info popup to don't stack & be removed correctly

### DIFF
--- a/Assets/Scripts/Barriers/Barrier.cs
+++ b/Assets/Scripts/Barriers/Barrier.cs
@@ -118,6 +118,7 @@ public class Barrier : MonoBehaviour
         if (other.CompareTag("Player"))
         {
             string infoText = GameManager.Instance.GetBarrierInfoText(type, originWorldIndex, destinationAreaIndex);
+            CloseInfoPanel(); //so if a info panel is open it will be closed before the new one opens
             OpenInfoPanel(infoText);
         }
     }
@@ -146,8 +147,9 @@ public class Barrier : MonoBehaviour
         {
             return;
         }
+
         string headerText = "";
-        switch(type)
+        switch (type)
         {
             case BarrierType.worldBarrier:
                 headerText = "World " + destinationAreaIndex;
@@ -157,6 +159,7 @@ public class Barrier : MonoBehaviour
                 headerText = "Dungeon " + originWorldIndex + "-" + destinationAreaIndex;
                 break;
         }
+
         InfoManager.Instance.DisplayInfo(headerText, infoText);
     }
 


### PR DESCRIPTION
Closes Gamify-IT/issues#392

To test try to stack info popups (for example the one from the barrier to world 2)