### PR TITLE
fix that player walk animation is played when player entered minigame spot

### DIFF
--- a/Assets/Scripts/Minigame Loading/MinigameStarting.cs
+++ b/Assets/Scripts/Minigame Loading/MinigameStarting.cs
@@ -41,6 +41,8 @@ public class MinigameStarting : MonoBehaviour
     /// <param name="highscore">highscore of the minigame for this configurationId</param>
     public void SetupMinigame(string game, string configurationId, int highscore)
     {
+        GameObject.FindGameObjectWithTag("Player").GetComponent<Animator>().enabled = false;
+
         PlayerAnimation.Instance.SetBusy(true);
         PlayerAnimation.Instance.DisableMovement();
 
@@ -57,7 +59,7 @@ public class MinigameStarting : MonoBehaviour
     private void SetupPanel()
     {
         gameText.text = game;
-        highscoreText.text = highscore.ToString() + " %";
+        highscoreText.text = highscore + " %";
     }
 
     /// <summary>
@@ -83,6 +85,7 @@ public class MinigameStarting : MonoBehaviour
     private void QuitMinigame()
     {
         Reset();
+        GameObject.FindGameObjectWithTag("Player").GetComponent<Animator>().enabled = true;
         PlayerAnimation.Instance.SetBusy(false);
         PlayerAnimation.Instance.EnableMovement();
         SceneManager.UnloadSceneAsync("MinigameStarting Overlay");

--- a/Assets/Scripts/Minigame Loading/MinigameStarting.cs
+++ b/Assets/Scripts/Minigame Loading/MinigameStarting.cs
@@ -41,7 +41,7 @@ public class MinigameStarting : MonoBehaviour
     /// <param name="highscore">highscore of the minigame for this configurationId</param>
     public void SetupMinigame(string game, string configurationId, int highscore)
     {
-        GameObject.FindGameObjectWithTag("Player").GetComponent<Animator>().enabled = false;
+        PlayerAnimation.Instance.playerAnimator.enabled = false;
 
         PlayerAnimation.Instance.SetBusy(true);
         PlayerAnimation.Instance.DisableMovement();
@@ -85,7 +85,7 @@ public class MinigameStarting : MonoBehaviour
     private void QuitMinigame()
     {
         Reset();
-        GameObject.FindGameObjectWithTag("Player").GetComponent<Animator>().enabled = true;
+        PlayerAnimation.Instance.playerAnimator.enabled = true;
         PlayerAnimation.Instance.SetBusy(false);
         PlayerAnimation.Instance.EnableMovement();
         SceneManager.UnloadSceneAsync("MinigameStarting Overlay");


### PR DESCRIPTION
Closes Gamify-IT/issues#350

To test enter mini game spot.