### PR TITLE
Load current state after a minigame in the background

### DIFF
--- a/.nginx/webgl.conf
+++ b/.nginx/webgl.conf
@@ -5,7 +5,7 @@ server {
     location / {
         root   /webgl;
         index  index.html;
-        try_files $uri /index.html;
+        try_files $uri /index.html =404;
     }
 
     error_page  404              /404.html;

--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -223,7 +223,7 @@ public class GameManager : MonoBehaviour
     public void MinigameDone()
     {
         Debug.Log("Start minigame respawn at: " + minigameRespawnPosition.x + ", " + minigameRespawnPosition.y);
-        Reload();
+        LoadingManager.Instance.ReloadDataAndCheckConsistency();
     }
 
     /// <summary>

--- a/Assets/Scripts/Scene Loading/LoadingManager.cs
+++ b/Assets/Scripts/Scene Loading/LoadingManager.cs
@@ -179,7 +179,24 @@ public class LoadingManager : MonoBehaviour
             Debug.Log("Game Manager not online yet.");
             return;
         }
+        
+        ReloadDataAndCheckConsistency();
+ 
+        slider.value = 0.85f;
+        progressText.text = "85%";
+        loadingText.text = "SETTING UP PLAYER...";
 
+        GameObject.FindGameObjectWithTag("Player").transform.position = playerPosition;
+
+        slider.value = 1;
+        progressText.text = "100%";
+        loadingText.text = "DONE...";
+
+        await SceneManager.UnloadSceneAsync("LoadingScreen");
+    }
+    
+    public async void ReloadDataAndCheckConsistency() {
+    
         AreaLocationDTO[] unlockedAreasOld = DataManager.Instance.GetPlayerData().unlockedAreas;
 
         Debug.Log("Start fetching data");
@@ -210,18 +227,6 @@ public class LoadingManager : MonoBehaviour
             string headerText = "";
             InfoManager.Instance.DisplayInfo(headerText, infoText);
         }
-
-        slider.value = 0.85f;
-        progressText.text = "85%";
-        loadingText.text = "SETTING UP PLAYER...";
-
-        GameObject.FindGameObjectWithTag("Player").transform.position = playerPosition;
-
-        slider.value = 1;
-        progressText.text = "100%";
-        loadingText.text = "DONE...";
-
-        await SceneManager.UnloadSceneAsync("LoadingScreen");
     }
 
     /// <summary>

--- a/Assets/Scripts/Scene Loading/LoadingManager.cs
+++ b/Assets/Scripts/Scene Loading/LoadingManager.cs
@@ -197,6 +197,7 @@ public class LoadingManager : MonoBehaviour
     
     public async void ReloadDataAndCheckConsistency() {
     
+        Debug.Log("Start getting old unlocked areas");
         AreaLocationDTO[] unlockedAreasOld = DataManager.Instance.GetPlayerData().unlockedAreas;
 
         Debug.Log("Start fetching data");
@@ -208,21 +209,38 @@ public class LoadingManager : MonoBehaviour
         Debug.Log("Validate data");
         if (loadingSuccesful)
         {
+
+            Debug.Log("Load offline mode");
             await SceneManager.LoadSceneAsync("OfflineMode", LoadSceneMode.Additive);
+            Debug.Log("Loaded offline mode");
             return;
         }
 
-        slider.value = 0.5f;
-        progressText.text = "50%";
-        loadingText.text = "PROCESSING DATA...";
+        if (slider != null) {
+            Debug.Log("set slider value");
+            slider.value = 0.5f;
+        }
+        if (progressText != null) {
+            Debug.Log("set progress text");
+            progressText.text = "50%";
+        }
+        if (loadingText != null) {
+            Debug.Log("set loading text");
+            loadingText.text = "PROCESSING DATA...";
+        }
 
+        Debug.Log("start setting data");
         GameManager.Instance.SetData(worldIndex, dungeonIndex);
+        Debug.Log("collect new unlocked areas");
         AreaLocationDTO[] unlockedAreasNew = DataManager.Instance.GetPlayerData().unlockedAreas;
+        Debug.Log("setup progressbar");
         SetupProgessBar(unlockedAreasNew);
+        Debug.Log("check for new unlocked areas");
         string infoText = CheckForNewUnlockedArea(unlockedAreasOld, unlockedAreasNew);
 
         if (infoText != "")
         {
+            Debug.Log("new areas have been unlocked");
             await SceneManager.LoadSceneAsync("InfoScreen", LoadSceneMode.Additive);
             string headerText = "";
             InfoManager.Instance.DisplayInfo(headerText, infoText);

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -13,6 +13,7 @@
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",
+    "com.unity.toolchain.linux-x86_64": "2.0.5",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.7.6",
     "com.unity.xr.legacyinputhelpers": "2.1.9",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -206,6 +206,22 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.sysroot": {
+      "version": "2.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "2.0.5",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.6"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
       "version": "1.1.31",
       "depth": 0,
@@ -235,6 +251,16 @@
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.linux-x86_64": {
+      "version": "2.0.5",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.6",
+        "com.unity.sysroot.linux-x86_64": "2.0.5"
       },
       "url": "https://packages.unity.com"
     },

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -126,7 +126,7 @@ services:
 
   overworld:
     container_name: overworld
-    image: ghcr.io/gamify-it/overworld:main
+    image: ghcr.io/gamify-it/overworld:bugfix-do-not-reload-after-minigame
     restart: always
     pull_policy: always
     volumes:


### PR DESCRIPTION
Previously, the overworld was forcefully reloaded once you completed a minigame.
Querying the current state has been offloaded into the background now.