### PR TITLE
Fixed acces to the world generation

### DIFF
--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -52,6 +52,7 @@ public class GameManager : MonoBehaviour
         return false;
 #endif
         courseId = Application.absoluteURL.Split("/")[^1];
+        courseId = courseId.Split("&")[^2];
         GameSettings.SetCourseID(courseId);
 
         string uri = overworldBackendPath + "/courses/" + courseId;

--- a/Assets/Scripts/Scene Loading/LoadFirstScene.cs
+++ b/Assets/Scripts/Scene Loading/LoadFirstScene.cs
@@ -14,7 +14,7 @@ public class LoadFirstScene : MonoBehaviour
     /// </summary>
     private void Start()
     {
-        Gamemode gamemode = Gamemode.PLAY;
+        Gamemode gamemode = GetGamemode();
 
         switch(gamemode)
         {
@@ -45,14 +45,13 @@ public class LoadFirstScene : MonoBehaviour
     private Gamemode GetGamemode()
     {
         //get gamemode parameter of url
-        string urlGamemodePart = Application.absoluteURL.Split("/")[^1];
+        string urlGamemodePart = Application.absoluteURL.Split("&")[^1];
 
         //get first part
-        string gamemodePart = urlGamemodePart.Split("-")[0];
-        gamemodePart = gamemodePart.ToUpper();
+        urlGamemodePart = urlGamemodePart.ToUpper();
 
         //try to parse to valid gamemode
-        bool success = System.Enum.TryParse<Gamemode>(gamemodePart, out Gamemode gamemode);
+        bool success = System.Enum.TryParse<Gamemode>(urlGamemodePart, out Gamemode gamemode);
         if (success)
         {
             Debug.Log("Specified gamemode: " + gamemode);
@@ -61,7 +60,7 @@ public class LoadFirstScene : MonoBehaviour
         else
         {
             Gamemode defaultGamemode = Gamemode.PLAY;
-            Debug.LogError("Incorrect gamemode specified: " + gamemodePart + ", setting default gamemode: " + defaultGamemode);
+            Debug.LogError("Incorrect gamemode specified: " + urlGamemodePart + ", setting default gamemode: " + defaultGamemode);
             return defaultGamemode;
         }
     }

--- a/Assets/Scripts/WorldGeneration/AreaGeneratorManager.cs
+++ b/Assets/Scripts/WorldGeneration/AreaGeneratorManager.cs
@@ -27,6 +27,7 @@ public class AreaGeneratorManager : MonoBehaviour
 
     //Data
     private string courseID;
+    private string startParameters;
     private bool demoMode;
     private AreaInformation currentArea;
     private AreaData areaData;
@@ -42,7 +43,11 @@ public class AreaGeneratorManager : MonoBehaviour
 #if UNITY_EDITOR
         courseID = "";
 #else
-        courseID = Application.absoluteURL.Split("/")[^1];
+        Debug.Log("Splitting Url: " + Application.absoluteURL);
+        startParameters = Application.absoluteURL.Split("/")[^1];
+        Debug.Log("Start Parameters: "  + startParameters);
+        courseID = startParameters.Split("&")[^2];
+        Debug.Log("Course ID: " + courseID);
 #endif
         SetupUI();
         demoMode = false;
@@ -172,7 +177,7 @@ public class AreaGeneratorManager : MonoBehaviour
 #endif
 
         //load data from backend
-        string path = GameSettings.GetOverworldBackendPath() + "/courses/" + courseID + "/areaMaps/" + currentArea.GetWorldIndex();
+        string path = GameSettings.GetOverworldBackendPath() + "/courses/" + courseID + "/area/" + currentArea.GetWorldIndex();
         if(currentArea.IsDungeon())
         {
             path += "/dungeon/" + currentArea.GetDungeonIndex();


### PR DESCRIPTION
It is now possible to acces play mode and world generation mode via different links.
One needs to add "&gamemode" with the respective gamemode written in lowercase in the landing page when first calling the overworld.