### PR TITLE
Bugfix movement within regexgame

### DIFF
--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -240,7 +240,7 @@ public class GameManager : MonoBehaviour
     {
         Debug.Log("Start minigame respawn at: " + minigameRespawnPosition.x + ", " + minigameRespawnPosition.y);
         Reload();
-        PlayerAnimation.Instance.EnableMovement();
+        PlayerAnimation.Instance.EnableMovement(); 
     }
 
     /// <summary>

--- a/Assets/Scripts/GameManager/GameManager.cs
+++ b/Assets/Scripts/GameManager/GameManager.cs
@@ -240,6 +240,7 @@ public class GameManager : MonoBehaviour
     {
         Debug.Log("Start minigame respawn at: " + minigameRespawnPosition.x + ", " + minigameRespawnPosition.y);
         Reload();
+        PlayerAnimation.Instance.EnableMovement();
     }
 
     /// <summary>

--- a/Assets/Scripts/Minigame Loading/Minigame.cs
+++ b/Assets/Scripts/Minigame Loading/Minigame.cs
@@ -191,5 +191,3 @@ public class Minigame : MonoBehaviour, IGameEntity<MinigameData>
     }
     #endregion
 }
-
-/// test

--- a/Assets/Scripts/Minigame Loading/Minigame.cs
+++ b/Assets/Scripts/Minigame Loading/Minigame.cs
@@ -191,3 +191,5 @@ public class Minigame : MonoBehaviour, IGameEntity<MinigameData>
     }
     #endregion
 }
+
+/// test

--- a/Assets/Scripts/Minigame Loading/MinigameStarting.cs
+++ b/Assets/Scripts/Minigame Loading/MinigameStarting.cs
@@ -100,6 +100,7 @@ public class MinigameStarting : MonoBehaviour
     public void QuitButtonPressed()
     {
         PlayClickSound();
+        PlayerAnimation.Instance.EnableMovement();
         Invoke("QuitMinigame", 0.3f);
     }
 

--- a/Assets/Scripts/Minigame Loading/MinigameStarting.cs
+++ b/Assets/Scripts/Minigame Loading/MinigameStarting.cs
@@ -91,7 +91,7 @@ public class MinigameStarting : MonoBehaviour
     {
         LoadMinigameInIframe(game, configurationId);
         PlayClickSound();
-        Invoke("QuitMinigame", 0.3f);
+        //Invoke("QuitMinigame", 0.3f);  // Makes no sense here ?!
     }
 
     /// <summary>

--- a/Assets/Scripts/Minigame Loading/MinigameStarting.cs
+++ b/Assets/Scripts/Minigame Loading/MinigameStarting.cs
@@ -91,7 +91,7 @@ public class MinigameStarting : MonoBehaviour
     {
         LoadMinigameInIframe(game, configurationId);
         PlayClickSound();
-        //Invoke("QuitMinigame", 0.3f);  // Makes no sense here ?!
+        Invoke("QuitMinigame", 0.3f); 
     }
 
     /// <summary>
@@ -111,7 +111,7 @@ public class MinigameStarting : MonoBehaviour
         Reset();
         PlayerAnimation.Instance.playerAnimator.enabled = true;
         PlayerAnimation.Instance.SetBusy(false);
-        PlayerAnimation.Instance.EnableMovement();
+        //PlayerAnimation.Instance.EnableMovement();  // too early
         SceneManager.UnloadSceneAsync("MinigameStarting Overlay");
     }
 

--- a/Assets/Scripts/Minigame Loading/MinigameStarting.cs
+++ b/Assets/Scripts/Minigame Loading/MinigameStarting.cs
@@ -112,7 +112,6 @@ public class MinigameStarting : MonoBehaviour
         Reset();
         PlayerAnimation.Instance.playerAnimator.enabled = true;
         PlayerAnimation.Instance.SetBusy(false);
-        //PlayerAnimation.Instance.EnableMovement();  // too early
         SceneManager.UnloadSceneAsync("MinigameStarting Overlay");
     }
 


### PR DESCRIPTION
Changed position of the enable movement call so that you cant move while playing a minigame (regexgame specifically).

When testing it is advised to use a local build of the regexgame and set the background to seethrough (in the global.css) to be able to see the overworld while in the minigame.